### PR TITLE
chore: Rename to task-local-extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution guidelines
 
-First off, thank you for considering contributing to truelayer-extensions.
+First off, thank you for considering contributing to task-local-extensions.
 
 If your contribution is not straightforward, please first discuss the change you
 wish to make by creating a new issue before making the change.
@@ -8,7 +8,7 @@ wish to make by creating a new issue before making the change.
 ## Reporting issues
 
 Before reporting an issue on the
-[issue tracker](https://github.com/TrueLayer/truelayer-extensions/issues),
+[issue tracker](https://github.com/TrueLayer/task-local-extensions/issues),
 please check that it has not already been reported by searching for some related
 keywords.
 
@@ -19,7 +19,7 @@ Try to do one pull request per change.
 ### Updating the changelog
 
 Update the changes you have made in
-[CHANGELOG](https://github.com/TrueLayer/truelayer-extensions/blob/master/CHANGELOG.md)
+[CHANGELOG](https://github.com/TrueLayer/task-local-extensions/blob/master/CHANGELOG.md)
 file under the **Unreleased** section.
 
 Add the changes of your pull request to one of the following subsections,
@@ -42,8 +42,8 @@ If the required subsection does not exist yet under **Unreleased**, create it!
 This is no different than other Rust projects.
 
 ```shell
-git clone https://github.com/TrueLayer/truelayer-extensions
-cd rust-truelayer-extensions
+git clone https://github.com/TrueLayer/task-local-extensions
+cd rust-task-local-extensions
 cargo test
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This is no different than other Rust projects.
 
 ```shell
 git clone https://github.com/TrueLayer/task-local-extensions
-cd rust-task-local-extensions
+cd task-local-extensions
 cargo test
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "truelayer-extensions"
+name = "task-local-extensions"
 version = "0.1.1-alpha.0"
 authors = ["Helge Hoff <helge.hoff@truelayer.com>"]
 edition = "2018"
 description = "Task-local container for arbitrary data."
-repository = "https://github.com/TrueLayer/truelayer-extensions"
+repository = "https://github.com/TrueLayer/task-local-extensions"
 license = "MIT OR Apache-2.0"
 keywords = ["extensions", "typemap"]
 

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 </sub>
 
-[`Extensions`](https://docs.rs/truelayer-extensions/latest/truelayer_extensions/struct.Extensions.html)
+[`Extensions`](https://docs.rs/task-local-extensions/latest/truelayer_extensions/struct.Extensions.html)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ task-local-extensions = "0.1.0"
 
 ## Usage
 
-[`Extensions`] is a container that can store up to one value of each type, so you can insert and
-retrive values by their type:
+[`Extensions`](https://docs.rs/task-local-extensions/latest/task_local_extensions/struct.Extensions.html)
+is a container that can store up to one value of each type, so you can insert and retrive values by
+their type:
 
 ```rust
 use task_local_extensions::Extensions;
@@ -31,8 +32,8 @@ extensions.insert(a);
 assert_eq!(ext.get::<i64>(), Some(&3));
 ```
 
-The crate also provides [`with_extensions`] so you set an `Extensions` instance while running a
-given task:
+The crate also provides [`with_extensions`](https://docs.rs/task-local-extensions/latest/task_local_extensions/fn.with_extensions.html)
+so you set an `Extensions` instance while running a given task:
 
 ```rust
 use task_local_extensions::{get_local_item, set_local_item, with_extensions, Extensions};
@@ -65,5 +66,3 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 </sub>
-
-[`Extensions`](https://docs.rs/task-local-extensions/latest/truelayer_extensions/struct.Extensions.html)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,54 @@
-# truelayer-extensions
+# task-local-extensions
 
-Provides a type-safe task-local container for arbitrary data keyed by types and asynchronous.
+Provides a type-safe task-local container for arbitrary data keyed by types.
 
-[![Crates.io](https://img.shields.io/crates/v/truelayer-extensions.svg)](https://crates.io/crates/truelayer-extensions)
-[![Docs.rs](https://docs.rs/truelayer-extensions/badge.svg)](https://docs.rs/truelayer-extensions)
-[![CI](https://github.com/TrueLayer/truelayer-extensions/workflows/CI/badge.svg)](https://github.com/TrueLayer/truelayer-extensions/actions)
-[![Coverage Status](https://coveralls.io/repos/github/TrueLayer/rust-truelayer-extensions/badge.svg?branch=main&t=DdH5KB)](https://coveralls.io/github/TrueLayer/rust-truelayer-extensions?branch=main)
+[![Crates.io](https://img.shields.io/crates/v/task-local-extensions.svg)](https://crates.io/crates/task-local-extensions)
+[![Docs.rs](https://docs.rs/task-local-extensions/badge.svg)](https://docs.rs/task-local-extensions)
+[![CI](https://github.com/TrueLayer/task-local-extensions/workflows/CI/badge.svg)](https://github.com/TrueLayer/task-local-extensions/actions)
+[![Coverage Status](https://coveralls.io/repos/github/TrueLayer/rust-task-local-extensions/badge.svg?branch=main&t=DdH5KB)](https://coveralls.io/github/TrueLayer/rust-task-local-extensions?branch=main)
 
 ## How to install
 
-Add `truelayer-extensions` to your dependencies
+Add `task-local-extensions` to your dependencies
 
 ```toml
 [dependencies]
 # ...
-truelayer-extensions = "0.1.0"
+task-local-extensions = "0.1.0"
+```
+
+## Usage
+
+[`Extensions`] is a container that can store up to one value of each type, so you can insert and
+retrive values by their type:
+
+```rust
+use task_local_extensions::Extensions;
+
+let a: i64 = 3;
+let mut ext = Extensions::new();
+extensions.insert(a);
+assert_eq!(ext.get::<i64>(), Some(&3));
+```
+
+The crate also provides [`with_extensions`] so you set an `Extensions` instance while running a
+given task:
+
+```rust
+use task_local_extensions::{get_local_item, set_local_item, with_extensions, Extensions};
+
+async fn my_task() {
+  let a: i64 = get_local_item().await.unwrap(0);
+  let msg = format!("The value of a is: {}", a);
+  set_local_item(msg).await;
+}
+
+let a: i64 = 3;
+let mut ext = Extensions::new();
+ext.insert(a);
+let (out_ext, _) = with_extensions(ext, my_task()).await;
+let msg = out_ext.get::<String>().unwrap();
+assert_eq!(msg.as_str(), "The value of a is: 3");
 ```
 
 #### License
@@ -31,3 +65,5 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 </sub>
+
+[`Extensions`](https://docs.rs/truelayer-extensions/latest/truelayer_extensions/struct.Extensions.html)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provides a type-safe task-local container for arbitrary data keyed by types.
 [![Crates.io](https://img.shields.io/crates/v/task-local-extensions.svg)](https://crates.io/crates/task-local-extensions)
 [![Docs.rs](https://docs.rs/task-local-extensions/badge.svg)](https://docs.rs/task-local-extensions)
 [![CI](https://github.com/TrueLayer/task-local-extensions/workflows/CI/badge.svg)](https://github.com/TrueLayer/task-local-extensions/actions)
-[![Coverage Status](https://coveralls.io/repos/github/TrueLayer/rust-task-local-extensions/badge.svg?branch=main&t=DdH5KB)](https://coveralls.io/github/TrueLayer/rust-task-local-extensions?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/TrueLayer/task-local-extensions/badge.svg?branch=main&t=DdH5KB)](https://coveralls.io/github/TrueLayer/task-local-extensions?branch=main)
 
 ## How to install
 


### PR DESCRIPTION
Rename the repo to make it clear this is not TL-specific, before this is merged we should change the repo name.

Also add some examples to the README.