### PR TITLE
add some new methods to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ async fn my_task() {
 }
 
 let a: i64 = 3;
-let mut ext = Extensions::new();
-ext.insert(a);
-let (out_ext, _) = with_extensions(ext, my_task()).await;
+let (out_ext, _) = with_extensions(Extensions::new().with(a), my_task()).await;
 let msg = out_ext.get::<String>().unwrap();
 assert_eq!(msg.as_str(), "The value of a is: 3");
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,35 @@
 //! A type map for storing data of arbritrary type.
+//!
+//! # Extensions
+//! [`Extensions`] is a container that can store up to one value of each type, so you can insert and retrive values by
+//! their type:
+//!
+//! ```
+//! use task_local_extensions::Extensions;
+//!
+//! let a: i64 = 3;
+//! let mut ext = Extensions::new();
+//! extensions.insert(a);
+//! assert_eq!(ext.get::<i64>(), Some(&3));
+//! ```
+//!
+//! # Task Local Extensions
+//! The crate also provides [`with_extensions`] so you set an [`Extensions`] instance while running a given task:
+//!
+//! ```
+//! use task_local_extensions::{get_local_item, set_local_item, with_extensions, Extensions};
+//!
+//! async fn my_task() {
+//!   let a: i64 = get_local_item().await.unwrap(0);
+//!   let msg = format!("The value of a is: {}", a);
+//!   set_local_item(msg).await;
+//! }
+//!
+//! let a: i64 = 3;
+//! let (out_ext, _) = with_extensions(Extensions::new().with(a), my_task()).await;
+//! let msg = out_ext.get::<String>().unwrap();
+//! assert_eq!(msg.as_str(), "The value of a is: 3");
+//! ```
 
 mod extensions;
 mod task_local;

--- a/src/task_local.rs
+++ b/src/task_local.rs
@@ -1,3 +1,7 @@
+// clippy bug wrongly flags the task_local macro as being bad.
+// a fix is already merged but hasn't made it upstream yet
+#![allow(clippy::declare_interior_mutable_const)]
+
 use crate::Extensions;
 use std::cell::RefCell;
 use std::future::Future;

--- a/src/task_local.rs
+++ b/src/task_local.rs
@@ -16,11 +16,11 @@ pub async fn with_extensions<T>(
     EXTENSIONS
         .scope(RefCell::new(extensions), async move {
             let response = fut.await;
-            let extensions = RefCell::new(Extensions::new());
+            let mut extensions = Extensions::new();
 
-            EXTENSIONS.with(|ext| ext.swap(&extensions));
+            EXTENSIONS.with(|ext| std::mem::swap(&mut *ext.borrow_mut(), &mut extensions));
 
-            (extensions.into_inner(), response)
+            (extensions, response)
         })
         .await
 }


### PR DESCRIPTION
Cleans up the code a little

- `HashMap::new()` is a cleap already so wrapping it in an Option is unnecessary.
- `with_extensions` doesn't need an extra `RefCell`, although that didn't cost too much anyway 🤷 

Adds 2 new methods to `Extensions`:
* `Extensions::with(self, T) -> Self` - a builder style insert for quickly initialising the extensions.
* `Extensions::append(&mut self, &mut Self)` - analogous to https://doc.rust-lang.org/std/vec/struct.Vec.html#method.append