### PR TITLE
chore: remove tokio rt dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2023-03-09
+### Changed
+- Switched out task-local impl from tokio to using a custom one. Allows for wasm32 compat now
+
 ## [0.1.3] - 2022-09-06
 ### Changed
 - The internal representation of `Extensions` no longer uses an `IdHasher` and instead uses the default hasher in order to be safe in case the representation of `TypeId` changes in future

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "task-local-extensions"
-version = "0.1.4-alpha0"
+version = "0.1.4"
 authors = ["Helge Hoff <helge.hoff@truelayer.com>"]
 edition = "2018"
 description = "Task-local container for arbitrary data."
@@ -9,4 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["extensions", "typemap"]
 
 [dependencies]
-tokio = { version = "1", features = ["rt"] }
+pin-utils = "0.1.0"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "task-local-extensions"
 version = "0.1.4"
-authors = ["Helge Hoff <helge.hoff@truelayer.com>"]
+authors = ["Conrad Ludgate <conrad.ludgate@truelayer.com>", "Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Task-local container for arbitrary data."
 repository = "https://github.com/TrueLayer/task-local-extensions"

--- a/src/task_local.rs
+++ b/src/task_local.rs
@@ -6,30 +6,38 @@ use crate::Extensions;
 use std::cell::RefCell;
 use std::future::Future;
 
-tokio::task_local! {
-    static EXTENSIONS: RefCell<Extensions>;
+thread_local! {
+    static EXTENSIONS: RefCell<Extensions> = RefCell::new(Extensions::new());
 }
 
 /// Sets a task local to `Extensions` before `fut` is run,
 /// and fetches the contents of the task local Extensions after completion
 /// and returns it.
 pub async fn with_extensions<T>(
-    extensions: Extensions,
+    mut extensions: Extensions,
     fut: impl Future<Output = T>,
 ) -> (Extensions, T) {
-    EXTENSIONS
-        .scope(RefCell::new(extensions), async move {
-            let response = fut.await;
-            let mut extensions = Extensions::new();
+    pin_utils::pin_mut!(fut);
+    let res = std::future::poll_fn(|cx| {
+        EXTENSIONS.with(|ext| {
+            // swap in the extensions
+            std::mem::swap(&mut extensions, &mut *ext.borrow_mut());
 
-            EXTENSIONS.with(|ext| std::mem::swap(&mut *ext.borrow_mut(), &mut extensions));
+            let res = fut.as_mut().poll(cx);
 
-            (extensions, response)
+            // swap back
+            std::mem::swap(&mut extensions, &mut *ext.borrow_mut());
+
+            res
         })
-        .await
+    })
+    .await;
+
+    (extensions, res)
 }
 
 /// Retrieve any item from task-local storage.
+// TODO: doesn't need to be async?
 pub async fn get_local_item<T: Send + Sync + Clone + 'static>() -> Option<T> {
     EXTENSIONS
         .try_with(|e| e.borrow().get::<T>().cloned())
@@ -38,8 +46,52 @@ pub async fn get_local_item<T: Send + Sync + Clone + 'static>() -> Option<T> {
 }
 
 /// Set an item in task-local storage.
+// TODO: doesn't need to be async?
 pub async fn set_local_item<T: Send + Sync + 'static>(item: T) {
     EXTENSIONS
         .try_with(|e| e.borrow_mut().insert(item))
         .expect("Failed to set local item.");
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{get_local_item, set_local_item, with_extensions, Extensions};
+
+    #[derive(Clone)]
+    struct A;
+    #[derive(Clone)]
+    struct B;
+
+    #[derive(Clone)]
+    struct C;
+
+    #[tokio::test]
+    async fn works() {
+        let mut a = Extensions::new();
+        a.insert(A);
+
+        let (a, _) = with_extensions(a, async {
+            let mut b = Extensions::new();
+            b.insert(B);
+
+            let (b, _) = with_extensions(b, async {
+                assert!(get_local_item::<A>().await.is_none());
+                assert!(get_local_item::<B>().await.is_some());
+                set_local_item(C).await;
+            })
+            .await;
+
+            // returned extension is correct
+            assert!(b.get::<B>().is_some());
+            assert!(b.get::<C>().is_some());
+
+            assert!(get_local_item::<A>().await.is_some());
+            assert!(get_local_item::<B>().await.is_none());
+            assert!(get_local_item::<C>().await.is_none());
+        })
+        .await;
+
+        // returned extension is correct
+        assert!(a.get::<A>().is_some());
+    }
 }


### PR DESCRIPTION
As pointed out in https://github.com/TrueLayer/reqwest-middleware/pull/79, we have a dependency on tokio. It's not necessary as it just provides task_locals. We can imitate that using thread locals